### PR TITLE
Fix responsive layout of Get NetLogo section on Homepage

### DIFF
--- a/src/components/index/get-netlogo.tsx
+++ b/src/components/index/get-netlogo.tsx
@@ -95,7 +95,7 @@ const GetNetLogo = ({ page_data, section_color }: GetNetLogoProps) => {
           <div className="row justify-content-center">
 
             {page_data.map((item) => (
-              <div key={item.title} className="col-md-4 d-flex justify-content-center">
+              <div key={item.title} className="col-lg-4 d-flex justify-content-center">
                 <ItemCard
                   title={item.title}
                   description={item.content}

--- a/src/components/shared/section.tsx
+++ b/src/components/shared/section.tsx
@@ -25,7 +25,7 @@ const Section = ({ sectionTitle, sectionDescript, sectionGap, sectionPaddingBot,
                 <div className="section-header">
                     <span className="section-title ms-n2">{sectionTitle}</span>
                     {/* Changed from span to div and using normalized text */}
-                    <div className="section-descript ms-n2">{normalizedDescript}</div>
+                    <div className="section-descript ms-n2 text-start">{normalizedDescript}</div>
                  </div>
                 {body} 
                 {moreButton && 


### PR DESCRIPTION
- Change product cards to using 4/12 columns until reaching large screen sizes
- Made product descriptions left-aligned